### PR TITLE
Add `main` property to `bower.json`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "ember-droplet",
   "version": "0.9.3",
   "homepage": "https://github.com/Wildhoney/EmberDroplet",
+  "main": "dist/ember-droplet.js",
   "authors": [
     "Adam Timberlake <adam.timberlake@gmail.com>"
   ],


### PR DESCRIPTION
A `main` property is required in `bower.json` to ensure the ember-droplet can be installed automatically via bower.  Without the `main` property you get the following error: 

```
[Error: Component JSON file "bower_components/ember-droplet/.bower.json" must have `main` property. See https://github.com/paulmillr/read-components#README]
```

Simple change but it means you can include ember-droplet as is without having to manually update `.bower.json` each time.
